### PR TITLE
Apollo/react-hooks integration

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -29,7 +29,6 @@ module.exports = ({ config }) => {
 
   config.resolve.alias = {
     "@pages": path.resolve(__dirname, '../pages'),
-    "@apollo": path.resolve(__dirname, '../src/apollo'),
     "@components": path.resolve(__dirname, '../src/components'),
     "@constants": path.resolve(__dirname, '../src/constants'),
     "@containers": path.resolve(__dirname, '../src/containers'),

--- a/package.json
+++ b/package.json
@@ -14,14 +14,16 @@
     "schema:download": "apollo client:download-schema --endpoint=http://localhost:4000/graphql --includes=./src/graphql/**/*.graphql"
   },
   "dependencies": {
+    "@apollo/react-hooks": "^0.1.0-beta.11",
+    "@apollo/react-ssr": "^0.1.0-beta.1",
+    "@apollo/react-testing": "^0.1.0-beta.6",
     "apollo-boost": "^0.4.3",
-    "apollo-mocked": "^0.2.3",
+    "apollo-mocked": "^0.2.10",
     "graphql": "^14.4.2",
     "isomorphic-unfetch": "^3.0.0",
     "next": "^9.0.2",
     "react": "^16.8.6",
     "react-apollo": "^2.5.8",
-    "react-apollo-hooks": "^0.5.0",
     "react-dom": "^16.8.6",
     "styled-components": "^4.3.2"
   },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import NextApp, { AppProps, Container } from 'next/app';
-import { ApolloProvider } from 'react-apollo-hooks';
+import { ApolloProvider } from '@apollo/react-hooks';
 import { ThemeProvider } from 'styled-components';
 import { withApollo, WithApolloProps } from '@containers/withApollo';
 import { styledTheme } from '@styled/theme';

--- a/pages/recipes/recipes.stories.tsx
+++ b/pages/recipes/recipes.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { ApolloLoadingProvider, ApolloErrorProvider, ApolloMockingProvider } from 'apollo-mocked';
-import { apolloMocks, introspectionResult } from '@utils/apolloMocks';
+import { ApolloLoadingProvider, ApolloErrorProvider, ApolloMockedProvider } from 'apollo-mocked';
+import { apolloMocks, typeDefs } from '@utils/apolloMocks';
 import Recipes from './';
 
 const recipesStories = storiesOf('Recipes', module);
@@ -19,10 +19,10 @@ recipesStories.add('error', () => (
 ));
 
 recipesStories.add('data', () => (
-  <ApolloMockingProvider
-    introspectionResult={introspectionResult}
+  <ApolloMockedProvider
+    typeDefs={typeDefs}
     mocks={apolloMocks}
   >
     <Recipes/>
-  </ApolloMockingProvider>
+  </ApolloMockedProvider>
 ));

--- a/pages/recipes/recipes.test.tsx
+++ b/pages/recipes/recipes.test.tsx
@@ -1,31 +1,38 @@
 import React from 'react';
 import { ApolloErrorProvider, ApolloLoadingProvider } from 'apollo-mocked';
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, render, waitForElement } from '@testing-library/react';
 import Recipes from './';
 
-afterEach(cleanup);
-
 describe('Recipes', () => {
-  it('should render loading component if query is in flight', () => {
-    const { debug } = render(
+  afterEach(cleanup);
+
+  it('should render loading component', async () => {
+    const loadingText = 'loading...';
+
+    const { getByText } = render(
       <ApolloLoadingProvider>
         <Recipes/>
       </ApolloLoadingProvider>
     );
 
-    debug();
+    const node = await waitForElement(() => getByText(loadingText));
+    expect(node.innerHTML).toEqual(loadingText);
   });
 
-  it('should render error component if query fails', async () => {
+  it('should render error component', async () => {
     const errorMessage = 'Failed to fetch recipes.';
+    const errorRes = `GraphQL error: ${errorMessage}`;
 
-    const { debug } = render((
+    const { getByText } = render((
       <ApolloErrorProvider errorMessages={errorMessage}>
         <Recipes/>
       </ApolloErrorProvider>
     ));
 
-    await Promise.resolve();
-    debug();
+    const node = await waitForElement(() => getByText(errorRes), {
+      timeout: 1000
+    });
+
+    expect(node.innerHTML).toEqual(errorRes);
   });
 });

--- a/src/containers/withApollo.tsx
+++ b/src/containers/withApollo.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Head from 'next/head';
 import AppComponent, { AppContext, AppProps } from 'next/app';
 import ApolloClient from 'apollo-client';
-import { getDataFromTree } from 'react-apollo';
+import { getDataFromTree } from '@apollo/react-ssr';
 import { initApollo } from '@utils/initApollo';
 
 export type WithApolloProps = {
@@ -17,7 +17,6 @@ type ApolloProps = AppProps & {
 export const withApollo = (App: typeof AppComponent) => {
   return class Apollo extends React.Component<ApolloProps> {
     static displayName = 'withApollo(App)';
-    public apolloClient: ApolloClient<{}>;
 
     static async getInitialProps (ctx: AppContext) {
       const { Component, router } = ctx;
@@ -61,6 +60,8 @@ export const withApollo = (App: typeof AppComponent) => {
 
       return { ...appProps, apolloState };
     }
+
+    public apolloClient: ApolloClient<{}>;
 
     constructor (props: ApolloProps) {
       super(props);

--- a/src/hooks/recipe/useAllRecipes.ts
+++ b/src/hooks/recipe/useAllRecipes.ts
@@ -1,15 +1,16 @@
-import { QueryHookResult, useQuery } from 'react-apollo-hooks';
+import { useQuery } from '@apollo/react-hooks';
+import { QueryResult } from 'react-apollo';
 import { allRecipesQuery } from '@constants/graphqlLoader';
 import { AllRecipesQuery } from '@typings/generated';
 import { Recipe } from '@typings/generated';
 
-type AllRecipesQueryResult = Omit<QueryHookResult<AllRecipesQuery, {}>, 'data'>;
+type AllRecipesQueryResult = Omit<QueryResult<AllRecipesQuery, {}>, 'data'>;
 type UseAllRecipes = () => AllRecipesQueryResult & {
   recipes: Recipe[];
 };
 
 export const useAllRecipes: UseAllRecipes = () => {
-  const { data, ...rest } = useQuery<AllRecipesQuery>(allRecipesQuery);
+  const { data, called, ...rest } = useQuery<AllRecipesQuery>(allRecipesQuery);
 
   const recipes =
     data &&

--- a/src/hooks/recipe/useRecipeById.ts
+++ b/src/hooks/recipe/useRecipeById.ts
@@ -1,9 +1,10 @@
-import { QueryHookResult, useQuery } from 'react-apollo-hooks';
+import { useQuery } from '@apollo/react-hooks';
+import { QueryResult } from '@apollo/react-common';
 import { recipeByIdQuery } from '@constants/graphqlLoader';
 import { RecipeByIdQuery, RecipeByIdQueryVariables, RecipeDetail } from '@typings/generated';
 import { Omit } from '@typings/shared';
 
-type RecipeByIdResult = Omit<QueryHookResult<RecipeByIdQuery, RecipeByIdQueryVariables>, 'data'>;
+type RecipeByIdResult = Omit<QueryResult<RecipeByIdQuery, RecipeByIdQueryVariables>, 'data'>;
 type UseRecipeById = (recipeId: number | string) => RecipeByIdResult & {
   recipe?: RecipeDetail;
 };

--- a/src/utils/apolloMocks.ts
+++ b/src/utils/apolloMocks.ts
@@ -1,9 +1,18 @@
 import IntrospectionResult from '../../schema.json';
+import TypeDefs from '../../schema.graphql';
 
 export const introspectionResult = IntrospectionResult;
+export const typeDefs = TypeDefs;
+
+export const mockResults = {
+  getAllRecipes: [
+    { id: 1, title: 'Pad Thai' },
+    { id: 2, title: 'Chicken Fried Rice' }
+  ],
+};
 
 export const apolloMocks = {
   Query: () => ({
-    getAllRecipes: () => [{ id: 1, title: 'Pad Thai'}, { id: 2, title: 'Chicken Fried Rice' } ]
+    getAllRecipes: () => mockResults.getAllRecipes
   }),
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,42 @@
 # yarn lockfile v1
 
 
+"@apollo/react-common@^0.1.0-beta.9":
+  version "0.1.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@apollo/react-common/-/react-common-0.1.0-beta.9.tgz#33d0a46d049d15e97b2f9f1e9e012c338567c1de"
+  integrity sha512-3/FYW7LilVlhfCkxL26Yglmr1LfWd2z+LEMHvtHF8K54Ejmb8kYglvDfbuAIsGT1f8WagpIkDm7eI1tfTdgNmw==
+  dependencies:
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+
+"@apollo/react-hooks@^0.1.0-beta.11":
+  version "0.1.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@apollo/react-hooks/-/react-hooks-0.1.0-beta.11.tgz#3b12836fb6fd944767757f5c7cb477ba880f6d52"
+  integrity sha512-hcEQWLFLpO2lN6AcXFsO/tK27Ve9+hIpw827fQBCuIbCyy2+e715ZMwrgzY5HCeCvLPY9DcS9I++0etr+f3UXw==
+  dependencies:
+    "@apollo/react-common" "^0.1.0-beta.9"
+    "@wry/equality" "^0.1.9"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+
+"@apollo/react-ssr@^0.1.0-beta.1":
+  version "0.1.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@apollo/react-ssr/-/react-ssr-0.1.0-beta.1.tgz#9e4c10f8b7e8e0c30564b0409ca787160fafe924"
+  integrity sha512-09AvAjrk3g3n5X4S5gsGOw2nYDlQ4ep3Qr4bPiQkhFM9IeYGQ6rWSaZIcAJDFL4IwnwdJQtoQDYXB1Muc9nuyw==
+  dependencies:
+    "@apollo/react-common" "^0.1.0-beta.9"
+    "@apollo/react-hooks" "^0.1.0-beta.11"
+    tslib "^1.10.0"
+
+"@apollo/react-testing@^0.1.0-beta.6":
+  version "0.1.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@apollo/react-testing/-/react-testing-0.1.0-beta.6.tgz#2f4b426f51fa9ecccc8be0431daf08dcab937898"
+  integrity sha512-DMC0V3ODLXdAGVu18fuJaHOHQxOU+Iom1ck/apNwBn6IvKsMAIwNmZLqss9uNkJqC8uL5mkoB94AHHADlzU8wA==
+  dependencies:
+    "@apollo/react-common" "^0.1.0-beta.9"
+    fast-json-stable-stringify "^2.0.0"
+    tslib "^1.10.0"
+
 "@apollographql/apollo-tools@0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@apollographql/apollo-tools/-/apollo-tools-0.4.0.tgz#8a1a0ab7a0bb12ccc03b72e4a104cfa5d969fd5f"
@@ -2404,7 +2440,7 @@
     "@types/node" ">=6"
     tslib "^1.9.3"
 
-"@wry/equality@^0.1.2":
+"@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.9.tgz#b13e18b7a8053c6858aa6c85b54911fb31e3a909"
   integrity sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==
@@ -2806,21 +2842,13 @@ apollo-link-http-common@^0.2.14:
     ts-invariant "^0.4.0"
     tslib "^1.9.3"
 
-apollo-link-http@^1.3.1, apollo-link-http@^1.5.15, apollo-link-http@^1.5.5:
+apollo-link-http@^1.3.1, apollo-link-http@^1.5.5:
   version "1.5.15"
   resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.15.tgz#106ab23bb8997bd55965d05855736d33119652cf"
   integrity sha512-epZFhCKDjD7+oNTVK3P39pqWGn4LEhShAoA1Q9e2tDrBjItNfviiE33RmcLcCURDYyW5JA6SMgdODNI4Is8tvQ==
   dependencies:
     apollo-link "^1.2.12"
     apollo-link-http-common "^0.2.14"
-    tslib "^1.9.3"
-
-apollo-link-schema@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/apollo-link-schema/-/apollo-link-schema-1.2.3.tgz#5e5bcd1c6177a72fe7ae8e104f7568a22c6bf392"
-  integrity sha512-cQ/PvJsV5tnlG2j7RCqgX4NZqA/N4JpoblN1l76N/56SFIoHU7mNujXc/tmPzBjJN6U+2BIbVKTcWJw0GvLWQA==
-  dependencies:
-    apollo-link "^1.2.12"
     tslib "^1.9.3"
 
 apollo-link@^1.0.0, apollo-link@^1.0.6, apollo-link@^1.2.12, apollo-link@^1.2.3:
@@ -2833,18 +2861,16 @@ apollo-link@^1.0.0, apollo-link@^1.0.6, apollo-link@^1.2.12, apollo-link@^1.2.3:
     tslib "^1.9.3"
     zen-observable-ts "^0.8.19"
 
-apollo-mocked@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/apollo-mocked/-/apollo-mocked-0.2.3.tgz#e910616068932d4e1977ed687dfd3c17d4158f27"
-  integrity sha512-FtSIvecPJaARnGM5b1KTlzJ71W/Eggh6D9JBJbiXMGlCOS9DS08shEJpIHOql+hjyE7vHf0lCY6oTM2gPUeMoA==
+apollo-mocked@^0.2.10:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/apollo-mocked/-/apollo-mocked-0.2.10.tgz#744cb095054cbbc5fcb8f5e912084c52e02066ff"
+  integrity sha512-OtjrYB1M9Um3hY7Ptuv3I7zmUz/diOVjp6+CDCNAf2TiCO4otEYzFG4DO4rFhatZGNLOct3R23ipZDxmpRufYg==
   dependencies:
+    "@apollo/react-hooks" "^0.1.0-beta.11"
     apollo-cache-inmemory "^1.6.2"
     apollo-client "^2.6.3"
-    apollo-link-http "^1.5.15"
-    apollo-link-schema "^1.2.3"
     graphql "^14.4.2"
     graphql-tools "^4.0.5"
-    react-apollo-hooks "^0.5.0"
 
 apollo-server-caching@0.4.0:
   version "0.4.0"
@@ -9751,13 +9777,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-apollo-hooks@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/react-apollo-hooks/-/react-apollo-hooks-0.5.0.tgz#49607fbe9cdfd0be08ea5defd39085bf5f42e10e"
-  integrity sha512-Us5KqFe7/c6vY1NaiyfhnD2Pz4lPLTojQXLppShaBVYU/vYvJrRjmj4MzIPXnExXaSfnQ+K2bWDr4lP4efbsRQ==
-  dependencies:
-    lodash "^4.17.11"
-
 react-apollo@^2.5.8:
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.8.tgz#c7a593b027efeefdd8399885e0ac6bec3b32623c"
@@ -11477,7 +11496,7 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.4.tgz#3b52b1f13924f460c3fbfd0df69b587dbcbc762e"
   integrity sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==
 
-ts-invariant@^0.4.0, ts-invariant@^0.4.2:
+ts-invariant@^0.4.0, ts-invariant@^0.4.2, ts-invariant@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
@@ -11503,7 +11522,7 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.2.tgz#be8e4bfce5d00f0f58e0666a82260c34a57af552"
   integrity sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA==
 
-tslib@^1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1, tslib@^1.10.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
removes any react-apollo-hooks dependency in favor of using apollo/react-hooks beta (we were going in this direction anyway)